### PR TITLE
Add is_complete property to tomes

### DIFF
--- a/pureskillgg_dsdk/tome/loader.py
+++ b/pureskillgg_dsdk/tome/loader.py
@@ -33,7 +33,7 @@ class TomeLoader:
         """If the tome is complete"""
         if not self._reader.exists:
             return False
-        return self._manifest.get("isComplete", False)
+        return self.manifest.get("isComplete", False)
 
     @property
     def manifest(self):

--- a/pureskillgg_dsdk/tome/loader.py
+++ b/pureskillgg_dsdk/tome/loader.py
@@ -35,7 +35,6 @@ class TomeLoader:
             return False
         return self._manifest.get("isComplete", False)
 
-
     @property
     def manifest(self):
         """Tome manifest"""

--- a/pureskillgg_dsdk/tome/loader.py
+++ b/pureskillgg_dsdk/tome/loader.py
@@ -29,6 +29,14 @@ class TomeLoader:
         return self._reader.exists
 
     @property
+    def is_complete(self):
+        """If the tome is complete"""
+        if not self._reader.exists:
+            return False
+        return self._manifest.get("isComplete", False)
+
+
+    @property
     def manifest(self):
         """Tome manifest"""
         self._load()


### PR DESCRIPTION
Should we just make them check instead? Just doing

```python
completed = loader.manifest["isComplete"]
```
will throw a file not found error. They'd have to do something like this:

```python
if loader.exists:
    completed = loader.manifest["isComplete"]
```

or wrap it in a try-except block