### PR TITLE
fix: switch to poetry-core build backend to fix PyPI sdist naming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,5 @@ pytest-runner = "^6.0.0"
 pytest-watch = "^4.2.0"
 
 [build-system]
-requires = ["poetry>=1.2"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
PyPI now enforces PEP 625, requiring underscores in sdist filenames. The legacy poetry.masonry.api backend produces hyphens; poetry.core.masonry.api normalizes correctly.