### PR TITLE
fix: include uv.lock in the version commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 3.0.1 / 2026-06-14
+
+### Fixed
+
+- Stage uv.lock in the version commit.
+
 ## 3.0.0 / 2026-06-14
 
 - Migrate to Python 3.11+ (CI test matrix 3.11-3.14).

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ watch:
 	@uv run ptw
 
 version:
-	@git add pyproject.toml
+	@git add pyproject.toml uv.lock
 	@git commit -m "$$(uv version --short)"
 	@git tag --sign "v$$(uv version --short)" -m "$(uv version --short)"
 	@git push --follow-tags

--- a/uv.lock
+++ b/uv.lock
@@ -1645,7 +1645,7 @@ wheels = [
 
 [[package]]
 name = "pureskillgg-dsdk"
-version = "2.0.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiobotocore" },


### PR DESCRIPTION
## Problem

`make version` (run by the `version` workflow after `uv version --bump`) staged only `pyproject.toml`. But `uv version` **re-locks `uv.lock`** too, so the lockfile's project version bump was discarded — every release shipped with `pyproject.toml` and `uv.lock` out of sync, and the next `format` run committed the lagging `uv.lock` as a spurious "Run format" commit.

## Fix

Stage `uv.lock` alongside `pyproject.toml` in the version target so the release commit is self-consistent.

```make
version:
	@git add pyproject.toml uv.lock
	...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)