### PR TITLE
docs: enrich dsdk README.rst with behavior, pipeline role, and deep-dive docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,223 @@ Python Data Science Development Kit.
 Description
 -----------
 
-Do data science for games.
+``pureskillgg-dsdk`` is the generic PureSkill.gg data-science SDK: a pure-Python
+library (package ``pureskillgg_dsdk``, published to PyPI) that provides the shared
+building blocks the CS2 ML / analytics code is written against. It reads
+parsed-demo data from S3, assembles training datasets ("tomes"), invokes ML
+models, consumes SQS work queues, and exports AWS Data Exchange revisions.
+
+This is a foundational **library, not a runtime service**. There are no Lambdas,
+no serverless config, no Terraform/CDK, and no CLI entry points here — everything
+is exported classes and functions consumed by other repos.
+
+What it does
+------------
+
+The top-level ``pureskillgg_dsdk/__init__.py`` re-exports a public API spread
+across five subpackages.
+
+**ds_io** — the reader layer for parsed-demo "ds" objects (default ``ds_type``
+``csds``, the parsed Counter-Strike demo data written to S3 as a JSON manifest
+plus per-channel parquet). ``GameDsLoader`` wraps a reader (``DsReaderS3`` or
+``DsReaderFs``) and exposes ``get_channels`` / ``get_channel``, which look up a
+named channel in the object's manifest and read its parquet payload into a pandas
+DataFrame; only ``application/x-parquet`` channels are supported. ``DsReaderS3``
+fetches the (optionally gzip-encoded) JSON manifest and S3 object metadata, and
+reads channel parquet via ``pd.read_parquet`` with a fallback path that re-reads
+the raw bytes through boto3 to work around a flaky Arrow/S3
+``FileNotFoundError``.
+
+**tome** — builds and reads "tomes": page-chunked training datasets aggregated
+across many matches. ``TomeCuratorFs`` is the high-level filesystem API (paths and
+``ds_type`` come from ``PURESKILLGG_TOME_*`` env vars). It creates header tomes
+(one row per match, scanned from a ds collection on disk), creates filtered
+subheader tomes via a selector, makes data tomes by iterating a header's keyset
+and concatenating per-channel DataFrames (``TomeMaker`` + ``TomeScribe`` +
+``TomeManifest``, with resumable continue/overwrite/pass/fail semantics and
+page-size / row-count splitting), and reads them back (``TomeLoader``,
+``get_dataframe`` / ``get_keyset`` / ``iterate_pages``, ``get_match_by_index`` /
+``get_random_match``). See `docs/tome-data-model.md <docs/tome-data-model.md>`_.
+
+**ds_models** — a model-invocation registry. ``create_ds_models(...).get_ds_model(name)``
+picks the first version of a named model and instantiates one of several backends:
+``SagemakerEndpoint`` (CSV to a SageMaker endpoint to a JSON DataFrame),
+``S3Scikit`` / ``S3ScikitSet`` (pickled scikit-learn models from S3), ``S3Dataframe``
+/ ``S3DataframeSet`` (CSV/parquet lookup tables), and ``S3Hashmap`` (JSON
+key-to-value). The ``*Set`` variants pick a specific artifact by matching a filter
+dict.
+
+**sqs** — ``SqsConsumer``, an asyncio / aiobotocore long-poll consumer with
+bounded concurrency that is the in-house replacement (added in dsdk 3.0) for the
+abandoned ``loafer`` package. It mirrors the loafer handler contract and is what
+the deployed Python workers use to pull jobs off SQS. See
+`docs/sqs-consumer.md <docs/sqs-consumer.md>`_.
+
+**adx** — wraps AWS Data Exchange: list/filter dataset revisions by comment date,
+and export revisions to the local filesystem or S3 (single, multiple, or
+auto-export via event actions), used for publishing and retrieving the academic
+data products.
+
+Pipeline role
+-------------
+
+This package ships to PyPI as ``pureskillgg-dsdk`` (currently v3.0.1) and is
+imported by the Python data-science / coaching repos — ``csgo-dsdk``,
+``csgo-datascience``, ``csgo-ppp``, ``csgo-coach`` (assistant-coach), and
+``csgo-progression``, plus the analysis workers.
+
+It sits **downstream of the demo parsers**: it reads the per-match "ds" objects
+(default ``ds_type`` ``csds``) that the replay / csds stage produces, and it
+provides the dataset-assembly, model-invocation, and queue-consumer plumbing
+those analytics jobs run on. Its ``sqs.SqsConsumer`` is the loafer replacement the
+deployed workers use to consume SQS.
+
+Public API
+----------
+
+Exported from ``pureskillgg_dsdk`` (confirmed via ``__init__.py``):
+
+- ``create_ds_models`` — model registry factory (``ds_models``).
+- ``DsReaderS3`` / ``DsReaderFs`` — backend readers for ds objects (manifest,
+  metadata, channel parquet) from S3 or local filesystem (``ds_io``).
+- ``GameDsLoader`` — resolves a channel in the manifest and loads its parquet
+  into a DataFrame (``ds_io``).
+- ``TomeCuratorFs`` / ``create_tome_curator`` — high-level make/read API for tomes
+  (``tome``).
+- ``SqsConsumer`` — asyncio/aiobotocore SQS long-poll consumer (``sqs``).
+- ``DeleteMessage`` — exception a handler may raise to force-ack (delete) a poison
+  message (``sqs``).
+- ``AbstractMessageTranslator`` / ``SqsJsonMessageTranslator`` — translate a raw
+  SQS message (JSON ``Body`` to content, the rest to metadata) for the consumer
+  (``sqs``).
+
+Major components
+----------------
+
+Only components/resources confirmed in the source are listed. This library owns
+**no** cloud resources — every bucket, queue, dataset, and endpoint identifier is
+a constructor or function argument supplied by the caller.
+
+ds_io
+~~~~~
+
+- **GameDsLoader** — ``get_channels`` / ``get_channel`` resolve a channel in the
+  ds manifest and load its parquet into a pandas DataFrame.
+- **DsReaderS3 / DsReaderFs** — read the manifest (gzip-aware JSON via
+  ``ContentEncoding``), metadata (S3 ``head_object``), and channel parquet, with a
+  ``FileNotFoundError`` boto3 fallback and ``handle_value_error`` for parquet
+  ``ValueError``. ``DsReaderS3`` takes the **bucket** as a constructor arg
+  (``<passed-in>``).
+
+tome
+~~~~
+
+- **TomeCuratorFs / create_tome_curator** — ``create_header_tome``,
+  ``create_subheader_tome``, ``make_tome``, ``get_dataframe`` / ``get_keyset`` /
+  ``get_manifest`` / ``iterate_pages``, ``get_match_by_index`` /
+  ``get_random_match``.
+- **TomeMaker / TomeScribe / TomeManifest / TomeLoader** — iterate a keyset and
+  concat per-match DataFrames into page-chunked parquet with a manifest;
+  resumable (continue/overwrite/pass/fail); read pages back.
+
+ds_models
+~~~~~~~~~
+
+- **create_ds_models / DsModels.get_ds_model** — select the first version of a
+  named model and build the matching backend.
+- **SagemakerEndpoint** — invokes a SageMaker runtime endpoint
+  (``boto3.client('runtime.sagemaker').invoke_endpoint``); ``endpoint_name`` comes
+  from the model dict (``<passed-in>``).
+- **S3Scikit** — pickled scikit-learn model from S3: ``MiniBatchKMeans``
+  (``predict``) and ``SGDClassifier`` (``predict_proba``).
+- **S3ScikitSet** — adds ``hdbscan.approximate_predict`` and requires an injected
+  ``hdbscan`` module (raises ``hdbscan must be injected`` if ``None``); reach it via
+  ``create_ds_models(hdbscan=...)``.
+- **S3Dataframe / S3DataframeSet** — CSV/parquet lookup tables.
+- **S3Hashmap** — JSON key-to-value lookups.
+
+  Dispatch is keyed on ``model['type']`` and individual S3 backends further branch
+  on ``model['model_type']`` / ``model['res_type']``; ``find_matching_model`` powers
+  the ``*Set`` artifact selection by filter dict.
+
+sqs
+~~~
+
+- **SqsConsumer** — ``consume()`` / ``start()`` / ``run()`` / ``stop()``, bounded
+  concurrency. Handler contract: a truthy return (or raising ``DeleteMessage``)
+  acks/deletes the message; a falsy return or exception leaves it for the queue's
+  redrive policy. Takes the **queue** name or URL as the ``queue`` kwarg
+  (``<passed-in>``; resolved via ``get_queue_url`` when it contains no ``://``) and an
+  optional ``region_name``.
+- **SqsJsonMessageTranslator / AbstractMessageTranslator** — JSON ``Body`` to
+  content, the rest to metadata.
+- **DeleteMessage** — force-ack exception.
+
+adx
+~~~
+
+- **get_adx_dataset_revisions** — list/filter revisions by comment date.
+- **download_adx_dataset_revision** — export a revision to the local filesystem.
+- **export_single_adx_dataset_revision_to_s3** /
+  **export_multiple_adx_dataset_revisions_to_s3** — create
+  ``EXPORT_REVISIONS_TO_S3`` jobs (``KeyPattern`` ``<prefix>${Asset.Name}``).
+- **enable_auto_exporting_adx_dataset_revisions_to_s3** /
+  **disable_auto_exporting_adx_dataset_revisions_to_s3** — manage a
+  ``RevisionPublished`` auto-export event action.
+
+  All ``dataset_id`` / ``revision_id`` values and the destination **bucket** are
+  ``<passed-in>``; the ``dataexchange`` client is used.
+
+Logs and observability
+----------------------
+
+This repo is a **pure-Python library**, not a deployed service. It contains no
+``serverless.yml``, no Terraform/CDK/SAM, no Lambda/Step Function/EventBridge/
+AppSync/DynamoDB/SNS definitions, declares **no log groups**, and has no Sentry
+integration and no ``LOG_LEVEL`` env handling. There are therefore no log groups,
+DLQs, or dashboards to find *in this repo* — those belong to the consuming
+service. The ``.github/workflows`` (main, format, publish, version) are CI/CD only
+(uv lint/test, PyPI publish, git tag) with no AWS deploy.
+
+How failures surface, within the host service that imports the library:
+
+- **Logging** uses ``structlog`` (``get_logger`` / ``log.bind(...)``). Log
+  destination and level are owned by the host. If the host is a Lambda or ECS
+  task, look under that service's own log group (e.g. ``/aws/lambda/...``).
+- **SqsConsumer** does **not** delete a message when the handler returns falsy or
+  raises; errors are routed through ``error_handler`` and logged as
+  ``SQS Consumer: Message error`` / ``Receive error`` (via ``log.exception``).
+  Undeleted messages stay on the source queue and rely on **that queue's own
+  redrive policy / DLQ**, which is defined in the consuming service's infra, not
+  here. A handler may raise ``DeleteMessage`` to force-ack a poison message.
+- **ADX export jobs** poll job state and raise on ``ERROR`` / ``CANCELLED`` /
+  ``TIMED_OUT``.
+- **TomeCuratorFs** reads ``PURESKILLGG_TOME_*`` env vars and raises
+  ``Missing option ...`` if neither the arg nor the env var is set.
+- **ds_io** raises on a missing manifest key and handles parquet ``ValueError``
+  via ``handle_value_error``.
+
+Configuration
+-------------
+
+``TomeCuratorFs`` reads these environment variables (each can also be passed as an
+arg; ``get_env_option`` raises ``Missing option {name}, pass in or set {KEY}`` if
+neither is present):
+
+- ``PURESKILLGG_TOME_DEFAULT_HEADER_NAME``
+- ``PURESKILLGG_TOME_DS_TYPE`` (default ``csds``)
+- ``PURESKILLGG_TOME_COLLECTION_PATH``
+- ``PURESKILLGG_TOME_DS_COLLECTION_PATH``
+
+Documentation
+-------------
+
+- `docs/tome-data-model.md <docs/tome-data-model.md>`_ — the tome / channel
+  dataset data model: how parsed match channels are stored and read, and the
+  ``TomeMaker`` / ``TomeScribe`` resume/paging logic.
+- `docs/sqs-consumer.md <docs/sqs-consumer.md>`_ — the ``SqsConsumer`` handler
+  contract, concurrency, shutdown, and error routing (the loafer-compatibility
+  behavior the workers depend on).
 
 Installation
 ------------

--- a/docs/sqs-consumer.md
+++ b/docs/sqs-consumer.md
@@ -1,0 +1,56 @@
+# SqsConsumer (the loafer replacement)
+
+`pureskillgg_dsdk.sqs.SqsConsumer` is the in-house SQS consumer added in dsdk
+3.0. It replaces the abandoned `loafer` package and is what the deployed
+PureSkill.gg Python workers use to pull jobs off SQS. It deliberately mirrors the
+loafer handler contract so worker code did not have to change.
+
+Source: `pureskillgg_dsdk/sqs/consumer.py`,
+`pureskillgg_dsdk/sqs/message_translators.py`,
+`pureskillgg_dsdk/sqs/exceptions.py`.
+
+## What it is
+
+An asyncio / aiobotocore **long-poll** consumer with **bounded concurrency**. The
+lifecycle methods are `consume()`, `start()`, `run()`, and `stop()`.
+
+- The **queue** is passed in as the `queue` kwarg. If it has no `://` it is
+  treated as a name and resolved via `get_queue_url`; otherwise it is used as a
+  URL. Region is the optional `region_name` kwarg.
+- No queue is created or declared by the library.
+
+## Handler contract
+
+The consumer calls `await handler(content, metadata)`:
+
+- A **truthy return** acks/deletes the message.
+- Raising **`DeleteMessage`** force-acks (deletes) the message — use it for a
+  poison message you want gone.
+- A **falsy return or any exception** leaves the message on the queue, so it
+  becomes visible again after the visibility timeout and ultimately follows the
+  **queue's own redrive policy / DLQ** (defined in the consuming service's infra,
+  not in this library).
+
+## Message translation
+
+The raw SQS message is run through a translator before reaching the handler:
+
+- `SqsJsonMessageTranslator` parses the JSON `Body` into `content` and puts the
+  rest of the message into `metadata`.
+- `AbstractMessageTranslator` is the base class for custom translators.
+- A **translate-stage failure or empty content** is routed exactly like a handler
+  exception (the message is not deleted).
+
+## Concurrency, shutdown, and error routing
+
+This is the loafer-compatibility behavior the workers rely on:
+
+- `CancelledError` (a `BaseException`) is allowed to **propagate** so shutdown is
+  clean; ordinary `Exception` is routed to the `error_handler`.
+- Errors are logged (`structlog`) as `SQS Consumer: Message error` /
+  `Receive error` via `log.exception`.
+- On shutdown, worker tasks are **cancelled and awaited before** the shared
+  aiobotocore client is closed, so in-flight work drains cleanly.
+
+There is no Sentry integration and no `LOG_LEVEL` handling here — the host
+service owns logging configuration and destination.

--- a/docs/tome-data-model.md
+++ b/docs/tome-data-model.md
@@ -1,0 +1,85 @@
+# Tome / channel dataset data model
+
+This is the dataset abstraction `pureskillgg_dsdk` standardizes. It is what
+`csgo-dsdk`, `csgo-datascience`, the coach, and progression all build training
+data on top of. Everything below lives in `pureskillgg_dsdk/ds_io` and
+`pureskillgg_dsdk/tome`.
+
+## The "ds" object (parsed match)
+
+A parsed demo is stored as a **"ds" object** (default `ds_type` `csds`), produced
+upstream by the replay / csds stage. Each ds object is:
+
+- a JSON **manifest** describing the object and its **channels**, and
+- one parquet payload **per channel**.
+
+`GameDsLoader` (wrapping `DsReaderS3` or `DsReaderFs`) is the reader:
+
+- `get_channels()` returns the channels declared in the manifest.
+- `get_channel(name)` looks the channel up in the manifest and reads its parquet
+  payload into a pandas DataFrame. Only `application/x-parquet` channels are
+  supported.
+
+`DsReaderS3` notes:
+
+- The manifest is fetched as JSON and is **gzip-aware** (honors
+  `ContentEncoding`).
+- Object metadata comes from S3 `head_object`.
+- Channel parquet is read via `pd.read_parquet`, with a fallback that re-reads
+  the raw bytes through boto3 to work around a flaky Arrow/S3
+  `FileNotFoundError`. Parquet `ValueError` is funneled through
+  `handle_value_error`.
+- The **bucket** is a constructor argument; the reader resolves keys under an
+  optional `prefix`. The library never hardcodes a bucket.
+
+`normalize_instructions` merges multiple read instructions for the same channel:
+the union of requested `columns`, or **all** columns if any instruction omits
+`columns`.
+
+## Tomes (page-chunked datasets across many matches)
+
+A **tome** aggregates many matches into a page-chunked parquet dataset plus a
+manifest. `TomeCuratorFs` (filesystem) is the high-level API. Its paths and
+`ds_type` come from `PURESKILLGG_TOME_*` env vars (or constructor args).
+
+Kinds of tome:
+
+- **Header tome** — one row per match, scanned from a ds collection on disk via
+  glob. Created with `create_header_tome`.
+- **Subheader tome** — a filtered header, produced with a selector, via
+  `create_subheader_tome`.
+- **Data tome** — the actual training data. `make_tome` iterates a header's
+  keyset and concatenates per-channel DataFrames into pages.
+
+Reading back:
+
+- `get_dataframe`, `get_keyset`, `get_manifest`, `iterate_pages`
+- `get_match_by_index`, `get_random_match`
+
+## make_tome resume / overwrite state machine
+
+`TomeMaker.make_tome` is the subtle part. It branches on whether a tome already
+exists and whether it is complete (`isComplete`), combined with
+`behavior_if_complete` and `behavior_if_partial` — each one of
+**continue / overwrite / pass / fail**:
+
+- **overwrite** rebuilds from scratch.
+- **fail** raises if the relevant state is present.
+- **pass** leaves the existing tome alone.
+- **continue** computes the remaining work as
+  `header_keyset - existing_keyset` and only builds those matches.
+- Special case: a **complete** tome with **continue** degrades to a passthrough
+  (nothing to do).
+
+## TomeScribe paging and manifest bookkeeping
+
+`TomeScribe` writes pages; `TomeManifest` records them. Gotchas:
+
+- Page splitting only triggers on a `limit_check_frequency` boundary **and** only
+  when `max_page_size_mb` or `max_page_row_count` is set.
+- The size check is **in-memory** size, which runs 2-10x larger than the parquet
+  on disk — budget pages accordingly.
+- `TomeManifest` builds the keyset and dataframe parquet keys and records
+  per-page and total timings.
+- An **empty tome is not supported** ("Empty Tome not supported"), and there is a
+  non-obvious copied-header key path to be aware of when reading the code.


### PR DESCRIPTION
## Summary

Replaces the thin top description of `README.rst` with concrete documentation of what `pureskillgg-dsdk` actually does, while keeping the file in valid reStructuredText and preserving the badge block and every boilerplate section verbatim.

### README.rst changes

- One-line summary plus a **What it does** section covering all five subpackages (`ds_io`, `tome`, `ds_models`, `sqs`, `adx`).
- **Pipeline role** section: this is a PyPI library (v3.0.1), not a runtime service; it sits downstream of the demo parsers and is consumed by `csgo-dsdk`, `csgo-datascience`, `csgo-ppp`, `csgo-coach`, and `csgo-progression`.
- **Public API** and **Major components** sections naming only verifier-confirmed exports/classes/functions (e.g. corrected `export_multiple_adx_dataset_revisions_to_s3`, and the `S3Scikit` vs `S3ScikitSet` hdbscan split).
- **Logs and observability** section making clear the repo owns no cloud resources / log groups; failures surface in the consuming service (structlog, SqsConsumer redrive behavior, ADX job state, tome env-var errors).
- **Configuration** section for the `PURESKILLGG_TOME_*` env vars.
- **Documentation** section linking the two new deep-dives.

### New docs

- `docs/tome-data-model.md` — the ds-object / channel / tome data model and the `make_tome` resume state machine plus `TomeScribe` paging gotchas.
- `docs/sqs-consumer.md` — the `SqsConsumer` handler contract, concurrency, shutdown, and error routing (loafer-compatibility).

All boilerplate (Installation, Development/Testing, Publishing, GitHub Actions secrets, Contributing, License, Warranty) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)