### PR TITLE
Add s3_xgboost ds-model type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - New `s3_xgboost` ds-model type: loads an XGBoost model saved with
   `save_model("*.json")` from S3 (`res_type: application/json`) and invokes
-  `predict_proba` (`model_type: XGBClassifier`). The `xgboost` module is
-  injected via `create_ds_models(xgboost=...)`, mirroring `hdbscan`, so the
-  package gains no xgboost dependency.
+  `predict_proba` (`model_type: XGBClassifier`). Requires the new `xgboost`
+  extra (`pureskillgg-dsdk[xgboost]`) — kept out of the base dependencies so
+  consumers that never load models don't ship the xgboost wheel.
 
 ## 3.0.1 / 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 3.1.0 / 2026-07-13
+
+### Added
+
+- New `s3_xgboost` ds-model type: loads an XGBoost model saved with
+  `save_model("*.json")` from S3 (`res_type: application/json`) and invokes
+  `predict_proba` (`model_type: XGBClassifier`). The `xgboost` module is
+  injected via `create_ds_models(xgboost=...)`, mirroring `hdbscan`, so the
+  package gains no xgboost dependency.
+
 ## 3.0.1 / 2026-06-14
 
 ### Fixed

--- a/pureskillgg_dsdk/ds_models/model.py
+++ b/pureskillgg_dsdk/ds_models/model.py
@@ -4,13 +4,15 @@ from .s3_dataframe import S3Dataframe
 from .s3_dataframe_set import S3DataframeSet
 from .s3_scikit import S3Scikit
 from .s3_scikit_set import S3ScikitSet
+from .s3_xgboost import S3Xgboost
 
 
 def create_ds_models(**kwargs):
     return DsModels(**kwargs)
 
 
-def create_ds_model(*, hdbscan=None, model, log):
+def create_ds_model(*, hdbscan=None, xgboost=None, model, log):
+    # pylint: disable=too-many-return-statements
     model_type = model["type"]
     if model_type == "sagemaker_endpoint":
         return SagemakerEndpoint(model=model, log=log)
@@ -24,14 +26,17 @@ def create_ds_model(*, hdbscan=None, model, log):
         return S3ScikitSet(hdbscan=hdbscan, model=model, log=log)
     if model_type == "s3_scikit":
         return S3Scikit(model=model, log=log)
+    if model_type == "s3_xgboost":
+        return S3Xgboost(xgboost=xgboost, model=model, log=log)
 
     raise Exception(f"Unknown model type: {model_type}")
 
 
 class DsModels:
-    def __init__(self, *, hdbscan=None, models, log):
+    def __init__(self, *, hdbscan=None, xgboost=None, models, log):
         self._models = models
         self._hdbscan = hdbscan
+        self._xgboost = xgboost
         self._log = log
 
     def get_ds_model(self, ds_model_name, /):
@@ -39,7 +44,12 @@ class DsModels:
         log = self._log.bind(ds_model=ds_model_name)
         log.info("Selected model version", model_meta=model_data["model_name"])
         log.debug("Model data:", model_data=model_data)
-        return create_ds_model(hdbscan=self._hdbscan, model=model_data, log=log)
+        return create_ds_model(
+            hdbscan=self._hdbscan,
+            xgboost=self._xgboost,
+            model=model_data,
+            log=log,
+        )
 
     def _pick_model_version(self, model_name):
         versions = self._models.get(model_name)

--- a/pureskillgg_dsdk/ds_models/model.py
+++ b/pureskillgg_dsdk/ds_models/model.py
@@ -11,7 +11,7 @@ def create_ds_models(**kwargs):
     return DsModels(**kwargs)
 
 
-def create_ds_model(*, hdbscan=None, xgboost=None, model, log):
+def create_ds_model(*, hdbscan=None, model, log):
     # pylint: disable=too-many-return-statements
     model_type = model["type"]
     if model_type == "sagemaker_endpoint":
@@ -27,16 +27,15 @@ def create_ds_model(*, hdbscan=None, xgboost=None, model, log):
     if model_type == "s3_scikit":
         return S3Scikit(model=model, log=log)
     if model_type == "s3_xgboost":
-        return S3Xgboost(xgboost=xgboost, model=model, log=log)
+        return S3Xgboost(model=model, log=log)
 
     raise Exception(f"Unknown model type: {model_type}")
 
 
 class DsModels:
-    def __init__(self, *, hdbscan=None, xgboost=None, models, log):
+    def __init__(self, *, hdbscan=None, models, log):
         self._models = models
         self._hdbscan = hdbscan
-        self._xgboost = xgboost
         self._log = log
 
     def get_ds_model(self, ds_model_name, /):
@@ -44,12 +43,7 @@ class DsModels:
         log = self._log.bind(ds_model=ds_model_name)
         log.info("Selected model version", model_meta=model_data["model_name"])
         log.debug("Model data:", model_data=model_data)
-        return create_ds_model(
-            hdbscan=self._hdbscan,
-            xgboost=self._xgboost,
-            model=model_data,
-            log=log,
-        )
+        return create_ds_model(hdbscan=self._hdbscan, model=model_data, log=log)
 
     def _pick_model_version(self, model_name):
         versions = self._models.get(model_name)

--- a/pureskillgg_dsdk/ds_models/s3_xgboost.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost.py
@@ -1,0 +1,45 @@
+from .s3_model import S3Model
+
+
+class S3Xgboost(S3Model):
+    def __init__(self, *, xgboost, model, log):
+        super().__init__(model, log)
+        self._model_type = model["model_type"]
+        self._key = model["key"]
+        self._xgboost = xgboost
+        self._loaded_model = None
+        self._log = log.bind(
+            client="s3_xgboost",
+            key=self._key,
+            bucket=self._bucket,
+            model_name=self.model_name,
+        )
+
+    def _load_model(self):
+        if self._res_type == "application/json":
+            model = self._read_json_model()
+            return model
+        raise Exception(f"Unknown res_type {self._res_type}")
+
+    def _read_json_model(self):
+        if self._xgboost is None:
+            raise Exception("xgboost must be injected")
+        body = self._s3_client.get_object(Bucket=self._bucket, Key=self._key)[
+            "Body"
+        ].read()
+        model = self._xgboost.XGBClassifier()
+        model.load_model(bytearray(body))
+        return model
+
+    def _use_model(self, dataframe):
+        if self._model_type == "XGBClassifier":
+            probabilities = self._loaded_model.predict_proba(dataframe)
+            return probabilities
+        raise Exception(f"Unknown model_type {self._model_type}")
+
+    def invoke(self, dataframe):
+        self._log.debug("Invoke: Start")
+        if self._loaded_model is None:
+            self._loaded_model = self._load_model()
+        probabilities = self._use_model(dataframe)
+        return probabilities

--- a/pureskillgg_dsdk/ds_models/s3_xgboost.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost.py
@@ -2,11 +2,10 @@ from .s3_model import S3Model
 
 
 class S3Xgboost(S3Model):
-    def __init__(self, *, xgboost, model, log):
+    def __init__(self, *, model, log):
         super().__init__(model, log)
         self._model_type = model["model_type"]
         self._key = model["key"]
-        self._xgboost = xgboost
         self._loaded_model = None
         self._log = log.bind(
             client="s3_xgboost",
@@ -22,12 +21,14 @@ class S3Xgboost(S3Model):
         raise Exception(f"Unknown res_type {self._res_type}")
 
     def _read_json_model(self):
-        if self._xgboost is None:
-            raise Exception("xgboost must be injected")
+        # Requires the xgboost extra: pureskillgg-dsdk[xgboost]
+        # pylint: disable=import-outside-toplevel
+        import xgboost
+
         body = self._s3_client.get_object(Bucket=self._bucket, Key=self._key)[
             "Body"
         ].read()
-        model = self._xgboost.XGBClassifier()
+        model = xgboost.XGBClassifier()
         model.load_model(bytearray(body))
         return model
 

--- a/pureskillgg_dsdk/ds_models/s3_xgboost.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost.py
@@ -21,9 +21,13 @@ class S3Xgboost(S3Model):
         raise Exception(f"Unknown res_type {self._res_type}")
 
     def _read_json_model(self):
-        # Requires the xgboost extra: pureskillgg-dsdk[xgboost]
         # pylint: disable=import-outside-toplevel
-        import xgboost
+        try:
+            import xgboost
+        except ImportError as error:
+            raise Exception(
+                "xgboost is not installed: install the pureskillgg-dsdk[xgboost] extra"
+            ) from error
 
         body = self._s3_client.get_object(Bucket=self._bucket, Key=self._key)[
             "Body"

--- a/pureskillgg_dsdk/ds_models/s3_xgboost_test.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost_test.py
@@ -1,8 +1,10 @@
-# pylint: disable=missing-docstring,invalid-name,attribute-defined-outside-init,protected-access
+# pylint: disable=missing-docstring,invalid-name,protected-access
 
 import io
 import os
 
+import numpy as np
+import xgboost
 from structlog import get_logger
 
 from .model import create_ds_models
@@ -23,28 +25,28 @@ MODELS = {
 }
 
 
-class FakeClassifier:
-    def load_model(self, buffer):
-        self.buffer = bytes(buffer)
-
-    def predict_proba(self, dataframe):
-        return [[0.25, 0.75] for _ in dataframe]
-
-
-class FakeXgboost:
-    XGBClassifier = FakeClassifier
-
-
 class FakeS3Client:
+    def __init__(self, body):
+        self._body = body
+
     def get_object(self, Bucket, Key):
         assert Bucket == "some-bucket"
         assert Key == "department/test/xgb_test/model_v1.json"
-        return {"Body": io.BytesIO(b'{"fake": "model"}')}
+        return {"Body": io.BytesIO(self._body)}
 
 
-def test_s3_xgboost_uses_injected_module():
-    models = create_ds_models(models=MODELS, xgboost=FakeXgboost(), log=get_logger())
+def test_s3_xgboost_matches_local_predictions(tmp_path):
+    rng = np.random.default_rng(0)
+    features = rng.random((80, 4))
+    target = (features[:, 0] > 0.5).astype(int)
+    trained = xgboost.XGBClassifier(n_estimators=4, max_depth=2)
+    trained.fit(features, target)
+    artifact = tmp_path / "model_v1.json"
+    trained.save_model(artifact)
+
+    models = create_ds_models(models=MODELS, log=get_logger())
     ds_model = models.get_ds_model("xgb_test")
-    ds_model._s3_client = FakeS3Client()
-    assert ds_model.invoke([1, 2]) == [[0.25, 0.75], [0.25, 0.75]]
-    assert ds_model._loaded_model.buffer == b'{"fake": "model"}'
+    ds_model._s3_client = FakeS3Client(artifact.read_bytes())
+
+    probabilities = ds_model.invoke(features)
+    np.testing.assert_array_equal(probabilities, trained.predict_proba(features))

--- a/pureskillgg_dsdk/ds_models/s3_xgboost_test.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost_test.py
@@ -1,0 +1,50 @@
+# pylint: disable=missing-docstring,invalid-name,attribute-defined-outside-init,protected-access
+
+import io
+import os
+
+from structlog import get_logger
+
+from .model import create_ds_models
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+MODELS = {
+    "xgb_test": [
+        {
+            "type": "s3_xgboost",
+            "model_name": "xgb_test_v1",
+            "model_type": "XGBClassifier",
+            "bucket": "some-bucket",
+            "key": "department/test/xgb_test/model_v1.json",
+            "res_type": "application/json",
+        }
+    ]
+}
+
+
+class FakeClassifier:
+    def load_model(self, buffer):
+        self.buffer = bytes(buffer)
+
+    def predict_proba(self, dataframe):
+        return [[0.25, 0.75] for _ in dataframe]
+
+
+class FakeXgboost:
+    XGBClassifier = FakeClassifier
+
+
+class FakeS3Client:
+    def get_object(self, Bucket, Key):
+        assert Bucket == "some-bucket"
+        assert Key == "department/test/xgb_test/model_v1.json"
+        return {"Body": io.BytesIO(b'{"fake": "model"}')}
+
+
+def test_s3_xgboost_uses_injected_module():
+    models = create_ds_models(models=MODELS, xgboost=FakeXgboost(), log=get_logger())
+    ds_model = models.get_ds_model("xgb_test")
+    ds_model._s3_client = FakeS3Client()
+    assert ds_model.invoke([1, 2]) == [[0.25, 0.75], [0.25, 0.75]]
+    assert ds_model._loaded_model.buffer == b'{"fake": "model"}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dependencies = [
     "pandas[performance,plot,output-formatting,computation,parquet,fss,aws]>=2.3.0,<3.0.0",
 ]
 
+[project.optional-dependencies]
+# For the s3_xgboost ds-model type. Not a base dependency so consumers that
+# never load models (e.g. Lambda pipelines) don't ship the xgboost wheel.
+# scikit-learn is required by xgboost's XGBClassifier sklearn API.
+xgboost = ["xgboost>=3.2,<4.0.0", "scikit-learn>=1.9,<2.0.0"]
+
 [project.urls]
 Homepage = "https://github.com/pureskillgg/dsdk"
 Repository = "https://github.com/pureskillgg/dsdk"
@@ -27,6 +33,8 @@ dev = [
     "pytest>=9.0.0,<10.0.0",
     "pytest-cov>=7.0.0,<8.0.0",
     "pytest-watch>=4.2.0,<5.0.0",
+    "xgboost>=3.2,<4.0.0",
+    "scikit-learn>=1.9,<2.0.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# For the s3_xgboost ds-model type. Not a base dependency so consumers that
-# never load models (e.g. Lambda pipelines) don't ship the xgboost wheel.
-# scikit-learn is required by xgboost's XGBClassifier sklearn API.
+# For s3_xgboost; optional so model-free consumers skip the wheel. XGBClassifier needs sklearn.
 xgboost = ["xgboost>=3.2,<4.0.0", "scikit-learn>=1.9,<2.0.0"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -752,6 +752,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1159,6 +1168,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
 name = "numba"
 version = "0.65.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1326,6 +1344,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
     { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
     { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.30.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8c/554bb020501d6c04ad8127d83f728137f8f9123f991666efbdcf9095a221/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:03ecd776fd1d58fd2c9a0a687dcf8db9ecd0057382dba646fa3d65786d4a9ea1", size = 303277471, upload-time = "2026-06-09T03:24:16.327Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/e7ffa9c324ae260e5dbb4af2cd557bf7a8d155c8ac7b79a785fe1796fb92/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:8ce1b8213f61f2bfac132e6df890af6450b77cbd140c6ce4e98cb0c2d8e678c9", size = 303361239, upload-time = "2026-06-09T03:24:53.816Z" },
 ]
 
 [[package]]
@@ -1657,6 +1684,13 @@ dependencies = [
     { name = "structlog" },
 ]
 
+[package.optional-dependencies]
+xgboost = [
+    { name = "scikit-learn" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "black" },
@@ -1664,6 +1698,9 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-watch" },
+    { name = "scikit-learn" },
+    { name = "xgboost", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "xgboost", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -1674,8 +1711,11 @@ requires-dist = [
     { name = "pandas", extras = ["performance", "plot", "output-formatting", "computation", "parquet", "fss", "aws"], specifier = ">=2.3.0,<3.0.0" },
     { name = "pyarrow", specifier = ">=16.0.0,<25.0.0" },
     { name = "python-rapidjson", specifier = ">=1.23.0,<2.0.0" },
+    { name = "scikit-learn", marker = "extra == 'xgboost'", specifier = ">=1.9,<2.0.0" },
     { name = "structlog", specifier = ">=26.0.0,<27.0.0" },
+    { name = "xgboost", marker = "extra == 'xgboost'", specifier = ">=3.2,<4.0.0" },
 ]
+provides-extras = ["xgboost"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1684,6 +1724,8 @@ dev = [
     { name = "pytest", specifier = ">=9.0.0,<10.0.0" },
     { name = "pytest-cov", specifier = ">=7.0.0,<8.0.0" },
     { name = "pytest-watch", specifier = ">=4.2.0,<5.0.0" },
+    { name = "scikit-learn", specifier = ">=1.9,<2.0.0" },
+    { name = "xgboost", specifier = ">=3.2,<4.0.0" },
 ]
 
 [[package]]
@@ -1954,6 +1996,51 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/e844fd9586e66540a15b71924d17a6cbc1bb749e81ddd0a796bcdba4c055/scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b", size = 8789686, upload-time = "2026-06-02T11:53:05.439Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e2/ff880f62677a17d035817d543cb0fc8727d01eccbee81c5f7fc733a9d856/scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c", size = 8256782, upload-time = "2026-06-02T11:53:08.904Z" },
+    { url = "https://files.pythonhosted.org/packages/25/64/eb40435e1a508ab1b4e284ce43ae80f6a162e5be5e38ed5a6fab467a9ea4/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa", size = 8992419, upload-time = "2026-06-02T11:53:11.551Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/4810a28e473185429e45a57eebcc91fc991b33d889cc0676063e671db03d/scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8", size = 9281411, upload-time = "2026-06-02T11:53:15.063Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/67/be3d369f40d8178ba3bd86635d132e08cb5329b023e4669d9426d84bc007/scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759", size = 8272736, upload-time = "2026-06-02T11:53:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/37/79/a733f02dc2118da7e77a134b34f39f40201a353311b011d20859d2db3556/scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28", size = 7919564, upload-time = "2026-06-02T11:53:21.2Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2049,6 +2136,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -2239,6 +2335,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version < '3.12' and sys_platform == 'linux'" },
+    { name = "scipy", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "nvidia-nccl-cu12", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
+    { name = "scipy", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/41/846d4de2b8fc694073fd3ac5052caf68caa1ea11cb7fa32d7ad9c049b232/xgboost-3.3.0.tar.gz", hash = "sha256:58bcb8a4cace648cdab7b94fa4f16d2c9ff26d90dd4d26907168106fa06d8746", size = 1224702, upload-time = "2026-06-17T21:26:50.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/72/3b68983c0215ef65d48e9eeb1f168c3c6e3d62a61ece605de3209c79cae1/xgboost-3.3.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:07688a377046b8640897b62421150bf73c6cc7101823474ec6ad08b93290f587", size = 2553505, upload-time = "2026-06-17T21:21:32.146Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/62/b49e756822b29909d0c95ed334662dc6c7c81a99ec6bc10dc18e69f3d6e7/xgboost-3.3.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:af7cea10f418b7c251ddc8da440f57bdab2990b5fc9f74a35a92b0f150ea287d", size = 2376040, upload-time = "2026-06-17T21:22:01.981Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/a0adcd1ee28f525bd5c9dc3ebe78a7599bf97c22866d6449f967b829e338/xgboost-3.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:624a83aeb1e7ba081719795db179f4ce6fff12e79de05cd9baf15ee48fd22f0e", size = 98180629, upload-time = "2026-06-17T21:24:00.804Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1f/8b3e578cfd8e3bcdb4374e2bbe0b40b4e5320accb5cbdcf535ecc512eb5c/xgboost-3.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f59edaf28eccd1c519788607c72ed907ee6cedfa933d706620bc1612d24b354e", size = 98716607, upload-time = "2026-06-17T21:26:21.058Z" },
+    { url = "https://files.pythonhosted.org/packages/07/6b/087fd5d28fdbb90d385c50ee9308a820241b82feebdf42e72e19a48e4b32/xgboost-3.3.0-py3-none-win_amd64.whl", hash = "sha256:b06057f6a018fc04e6b3e0c15568ca636b8151a5b5f333478e500fcaf4fc7594", size = 69522696, upload-time = "2026-06-17T21:20:53.707Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

New `s3_xgboost` model type in `ds_models`: loads an XGBoost model saved with the native `save_model(*.json)` format from S3 (`res_type: application/json`) and invokes `predict_proba` (`model_type: XGBClassifier`).

xgboost is a **declared optional extra** — `pureskillgg-dsdk[xgboost]` (which also pulls scikit-learn, required by the XGBClassifier sklearn API) — with a plain in-function import in the loader. No injection (that pattern exists for hdbscan only because hdbscan''s packaging was broken). It''s not a base dependency because csgo-ppp and other pipeline consumers of dsdk never load models and shouldn''t ship the ~200MB xgboost wheel. Consumers that already depend on xgboost directly (csgo-coach) need nothing beyond dsdk >=3.1.0.

Test trains a real tiny XGBClassifier, round-trips it through a fake S3 body, and asserts exact predict_proba parity.

## Why

csgo-coach currently bakes `xgb_model_v1.json` (win_probability) into its Docker image and loads it from disk, bypassing the ds-models path every other model uses. This type lets that model live in the AI bucket and be registered/versioned in models.yaml like everything else. The XGBoost json format is version-stable, unlike pickles, so this is also the preferred serving route for future ML models.

## Rollout (dependency chain)

1. This PR → release **3.1.0** to PyPI.
2. pureskillgg/reactor#25 (schema allows `s3_xgboost` in models.yaml) → release.
3. pureskillgg/csgo-assessment#90 registers `xgb_win_probability`; pureskillgg/csgo-coach#220 switches win_probability to `get_ds_model`.

A models.json entry with an unknown type is inert for consumers on dsdk <3.1.0 unless `get_ds_model` is called on that specific model, so merge order across consumers is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)