### PR TITLE
Add Booster model_type and parquet dataframes to ds_models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 3.2.0
+
+### Added
+
+- `s3_xgboost` accepts `model_type: Booster`: loads the artifact with
+  `xgboost.Booster` and predicts through a `DMatrix` built with
+  `enable_categorical=True` — serves regressors (e.g. `survival:aft` or
+  percentile-target models saved via `save_model`) and softprob classifiers
+  through one code path, including models with pandas categorical features.
+- `s3_dataframe` accepts `res_type: application/x-parquet` for parquet
+  artifacts (large lookup tables where CSV is impractical).
+
 ## 3.1.0 / 2026-07-13
 
 ### Added

--- a/pureskillgg_dsdk/ds_models/s3_dataframe.py
+++ b/pureskillgg_dsdk/ds_models/s3_dataframe.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from io import BytesIO, StringIO
 
 import pandas as pd
 
@@ -19,6 +19,8 @@ class S3Dataframe(S3Model):
     def _load_model(self):
         if self._res_type == "text/csv":
             self._model_data = self._read_csv()
+        elif self._res_type == "application/x-parquet":
+            self._model_data = self._read_parquet()
         else:
             raise Exception(f"Unknown res type {self._res_type}")
 
@@ -26,6 +28,10 @@ class S3Dataframe(S3Model):
         res = self._s3_client.get_object(Bucket=self._bucket, Key=self._key)
         body = res["Body"].read().decode("utf-8")
         return pd.read_csv(StringIO(body))
+
+    def _read_parquet(self):
+        res = self._s3_client.get_object(Bucket=self._bucket, Key=self._key)
+        return pd.read_parquet(BytesIO(res["Body"].read()))
 
     def invoke(self):
         self._log.debug("Invoke: Start")

--- a/pureskillgg_dsdk/ds_models/s3_dataframe_test.py
+++ b/pureskillgg_dsdk/ds_models/s3_dataframe_test.py
@@ -1,4 +1,5 @@
 # pylint: disable=missing-docstring,invalid-name,protected-access
+# pylint: disable=no-value-for-parameter
 
 import io
 import os

--- a/pureskillgg_dsdk/ds_models/s3_dataframe_test.py
+++ b/pureskillgg_dsdk/ds_models/s3_dataframe_test.py
@@ -1,0 +1,46 @@
+# pylint: disable=missing-docstring,invalid-name,protected-access
+
+import io
+import os
+
+import pandas as pd
+from structlog import get_logger
+
+from .model import create_ds_models
+
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
+MODELS = {
+    "frame_test": [
+        {
+            "type": "s3_dataframe",
+            "model_name": "frame_test_v1",
+            "bucket": "some-bucket",
+            "key": "department/test/frame_test/frame_v1.parquet",
+            "res_type": "application/x-parquet",
+        }
+    ]
+}
+
+
+class FakeS3Client:
+    def __init__(self, body):
+        self._body = body
+
+    def get_object(self, Bucket, Key):
+        assert Bucket == "some-bucket"
+        assert Key == "department/test/frame_test/frame_v1.parquet"
+        return {"Body": io.BytesIO(self._body)}
+
+
+def test_s3_dataframe_parquet_round_trip(tmp_path):
+    frame = pd.DataFrame({"map_name": ["de_dust2", "de_mirage"], "value": [0.25, 0.75]})
+    artifact = tmp_path / "frame_v1.parquet"
+    frame.to_parquet(artifact, index=False)
+
+    models = create_ds_models(models=MODELS, log=get_logger())
+    ds_model = models.get_ds_model("frame_test")
+    ds_model._s3_client = FakeS3Client(artifact.read_bytes())
+
+    loaded = ds_model.invoke()
+    pd.testing.assert_frame_equal(loaded, frame)

--- a/pureskillgg_dsdk/ds_models/s3_xgboost.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost.py
@@ -21,18 +21,14 @@ class S3Xgboost(S3Model):
         raise Exception(f"Unknown res_type {self._res_type}")
 
     def _read_json_model(self):
-        # pylint: disable=import-outside-toplevel
-        try:
-            import xgboost
-        except ImportError as error:
-            raise Exception(
-                "xgboost is not installed: install the pureskillgg-dsdk[xgboost] extra"
-            ) from error
-
+        xgboost = self._import_xgboost()
         body = self._s3_client.get_object(Bucket=self._bucket, Key=self._key)[
             "Body"
         ].read()
-        model = xgboost.XGBClassifier()
+        if self._model_type == "Booster":
+            model = xgboost.Booster()
+        else:
+            model = xgboost.XGBClassifier()
         model.load_model(bytearray(body))
         return model
 
@@ -40,7 +36,22 @@ class S3Xgboost(S3Model):
         if self._model_type == "XGBClassifier":
             probabilities = self._loaded_model.predict_proba(dataframe)
             return probabilities
+        if self._model_type == "Booster":
+            xgboost = self._import_xgboost()
+            dmatrix = xgboost.DMatrix(dataframe, enable_categorical=True)
+            return self._loaded_model.predict(dmatrix)
         raise Exception(f"Unknown model_type {self._model_type}")
+
+    @staticmethod
+    def _import_xgboost():
+        # pylint: disable=import-outside-toplevel
+        try:
+            import xgboost
+        except ImportError as error:
+            raise Exception(
+                "xgboost is not installed: install the pureskillgg-dsdk[xgboost] extra"
+            ) from error
+        return xgboost
 
     def invoke(self, dataframe):
         self._log.debug("Invoke: Start")

--- a/pureskillgg_dsdk/ds_models/s3_xgboost.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost.py
@@ -27,8 +27,10 @@ class S3Xgboost(S3Model):
         ].read()
         if self._model_type == "Booster":
             model = xgboost.Booster()
-        else:
+        elif self._model_type == "XGBClassifier":
             model = xgboost.XGBClassifier()
+        else:
+            raise Exception(f"Unknown model_type {self._model_type}")
         model.load_model(bytearray(body))
         return model
 

--- a/pureskillgg_dsdk/ds_models/s3_xgboost_test.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost_test.py
@@ -88,4 +88,4 @@ def test_s3_xgboost_booster_matches_local_predictions(tmp_path):
 
     predictions = ds_model.invoke(frame)
     expected = trained.predict(xgboost.DMatrix(frame, enable_categorical=True))
-    np.testing.assert_array_equal(predictions, expected)
+    np.testing.assert_allclose(predictions, expected, rtol=1e-6)

--- a/pureskillgg_dsdk/ds_models/s3_xgboost_test.py
+++ b/pureskillgg_dsdk/ds_models/s3_xgboost_test.py
@@ -21,17 +21,28 @@ MODELS = {
             "key": "department/test/xgb_test/model_v1.json",
             "res_type": "application/json",
         }
-    ]
+    ],
+    "booster_test": [
+        {
+            "type": "s3_xgboost",
+            "model_name": "booster_test_v1",
+            "model_type": "Booster",
+            "bucket": "some-bucket",
+            "key": "department/test/booster_test/model_v1.json",
+            "res_type": "application/json",
+        }
+    ],
 }
 
 
 class FakeS3Client:
-    def __init__(self, body):
+    def __init__(self, body, key="department/test/xgb_test/model_v1.json"):
         self._body = body
+        self._key = key
 
     def get_object(self, Bucket, Key):
         assert Bucket == "some-bucket"
-        assert Key == "department/test/xgb_test/model_v1.json"
+        assert Key == self._key
         return {"Body": io.BytesIO(self._body)}
 
 
@@ -50,3 +61,31 @@ def test_s3_xgboost_matches_local_predictions(tmp_path):
 
     probabilities = ds_model.invoke(features)
     np.testing.assert_array_equal(probabilities, trained.predict_proba(features))
+
+
+def test_s3_xgboost_booster_matches_local_predictions(tmp_path):
+    import pandas as pd  # pylint: disable=import-outside-toplevel
+
+    rng = np.random.default_rng(0)
+    frame = pd.DataFrame(
+        {
+            "a": rng.random(80),
+            "b": rng.random(80),
+            "map_name": pd.Categorical(rng.choice(["de_dust2", "de_mirage"], 80)),
+        }
+    )
+    target = frame["a"].to_numpy() + rng.random(80)
+    dtrain = xgboost.DMatrix(frame, label=target, enable_categorical=True)
+    trained = xgboost.train({"max_depth": 2, "seed": 0}, dtrain, num_boost_round=4)
+    artifact = tmp_path / "model_v1.json"
+    trained.save_model(artifact)
+
+    models = create_ds_models(models=MODELS, log=get_logger())
+    ds_model = models.get_ds_model("booster_test")
+    ds_model._s3_client = FakeS3Client(
+        artifact.read_bytes(), key="department/test/booster_test/model_v1.json"
+    )
+
+    predictions = ds_model.invoke(frame)
+    expected = trained.predict(xgboost.DMatrix(frame, enable_categorical=True))
+    np.testing.assert_array_equal(predictions, expected)


### PR DESCRIPTION
## Why

Shipping predicted FACEIT level / Premier rating to the scoreboard needs three XGBoost artifacts served by the coach: a 10-class softprob classifier, a censored `survival:aft` booster, and a percentile-target regressor — plus several parquet reference tables (llr grids, headshot-angle lookup, death-danger percentiles) too large for CSV.

## What

- `s3_xgboost` accepts `model_type: Booster`: loads with `xgboost.Booster` and predicts through `DMatrix(..., enable_categorical=True)` — one code path for regressors, AFT boosters, and softprob classifiers, including models with pandas categorical features. Existing `XGBClassifier` path untouched.
- `s3_dataframe` accepts `res_type: application/x-parquet`.

Reactor's models.yaml schema already takes `model_type`/`res_type` as free strings, so no schema pair needed this time.

## Tests

- Booster round-trip vs local predictions (incl. a categorical feature)
- Parquet dataframe round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)